### PR TITLE
AC-94 Fill incomplete timezone in encouter DateTime

### DIFF
--- a/api/src/main/resources/org/openmrs/module/xforms/form_xslt.xml
+++ b/api/src/main/resources/org/openmrs/module/xforms/form_xslt.xml
@@ -608,6 +608,25 @@ This XSLT is used to translate OpenMRS forms from XML into HL7 2.5 format
 	</xsl:if>
 </xsl:template>
 
+<!-- Generate HL7-formatted timestamp with support for android client-->
+<xsl:template name="hl7DateTime">
+    <xsl:param name="date" />
+    <xsl:if test="string($date) != ''">
+        <xsl:choose>
+            <xsl:when test="(contains(string($date),'+') and string-length(substring-after($date,'+')) &lt; 3) or (contains(substring-after($date,':'),'-') and string-length(substring-after(substring-after($date,':'),'-')) &lt; 3)">
+                <xsl:call-template name="hl7Timestamp">
+                    <xsl:with-param name="date" select="xs:dateTime(concat($date, ':00'))" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="hl7Timestamp">
+                    <xsl:with-param name="date" select="$date" />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+</xsl:template>
+
 <!-- Generate HL7-formatted date -->
 <xsl:template name="hl7Date">
 	<xsl:param name="date" />


### PR DESCRIPTION
Vitals send via android client contains encounter datetime witch incomplete timezone (2015-02-11T12:36:00.000+01), which cause error during validate.