### PR TITLE
Fixed issue XFRM -207

### DIFF
--- a/api/src/main/java/org/openmrs/module/xforms/XformBuilder.java
+++ b/api/src/main/java/org/openmrs/module/xforms/XformBuilder.java
@@ -528,6 +528,9 @@ public final class XformBuilder implements GlobalPropertyListener {
 	public static void setNodeValue(Element node, String value) {
 		if (value == null)
 			value = "";
+			
+		if (node == null)
+			return;
 		
 		for (int i = 0; i < node.getChildCount(); i++) {
 			if (node.isText(i)) {


### PR DESCRIPTION
There is a function in xFormBuilder.java, setNodeValue(Element, String) that does not handle the case where the Element node is null. 
I added a condition where the function immediately returns if Element is null (since there no node of which to set the value).